### PR TITLE
Ability to edit Billboard Bone Type

### DIFF
--- a/src/editors/skel.rs
+++ b/src/editors/skel.rs
@@ -1,3 +1,4 @@
+use crate::widgets::enum_combo_box;
 use egui::ScrollArea;
 use log::error;
 use rfd::FileDialog;
@@ -37,6 +38,7 @@ pub fn skel_editor(ctx: &egui::Context, title: &str, skel: &mut SkelData) -> boo
                         // Header
                         ui.heading("Bone");
                         ui.heading("Parent");
+                        ui.heading("Billboard Type");
                         ui.end_row();
 
                         // TODO: Do this without clone?
@@ -64,6 +66,9 @@ pub fn skel_editor(ctx: &egui::Context, title: &str, skel: &mut SkelData) -> boo
                                         );
                                     }
                                 });
+
+                            enum_combo_box(ui, "", i + other_bones.len(), &mut bone.billboard_type);
+
                             ui.end_row();
                         }
                     });

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -90,7 +90,9 @@ pub fn enum_combo_box<V>(
     V: PartialEq + strum::VariantNames + ToString + FromStr,
     <V as FromStr>::Err: std::fmt::Debug,
 {
-    ui.label(label);
+    if label != "" {
+        ui.label(label);
+    }
 
     egui::ComboBox::from_id_source(id_source)
         .width(200.0)


### PR DESCRIPTION
The code for the enum values can be more optimized if <a href="https://docs.rs/strum/latest/strum/"> the strum crate</a> but I was hesitant about adding more dependencies to the Cargo.toml for something so minor.

<img src="https://user-images.githubusercontent.com/6856627/177212582-c047c61a-127f-4286-9dc2-30738668404d.png" data-canonical-src="https://user-images.githubusercontent.com/6856627/177212582-c047c61a-127f-4286-9dc2-30738668404d.png" width="1000" />
<img src="https://user-images.githubusercontent.com/6856627/177212608-8018a73c-40a8-4853-9693-81a995477e13.png" data-canonical-src="https://user-images.githubusercontent.com/6856627/177212608-8018a73c-40a8-4853-9693-81a995477e13.png" width="1000" />