### PR TITLE
Material Preset window no longer resizable

### DIFF
--- a/src/editors/matl.rs
+++ b/src/editors/matl.rs
@@ -125,6 +125,7 @@ fn preset_window(
     let mut open = ui_state.preset_window_open;
     Window::new("Select Material Preset")
         .open(&mut ui_state.preset_window_open)
+        .resizable(false)
         .show(ctx, |ui| {
             for (i, preset) in material_presets.iter().enumerate() {
                 ui.selectable_value(


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/6856627/178082822-52a0cbac-018f-4f7a-8b26-3d5f99c899af.gif)
This was weird so I made the window no longer resizable. I guess you could change the min_width but I didn't know an exact number.