### PR TITLE
Moved param_label from matl.rs to material.rs

### DIFF
--- a/src/editors/anim.rs
+++ b/src/editors/anim.rs
@@ -86,6 +86,8 @@ fn edit_track(ui: &mut egui::Ui, track: &mut ssbh_data::anim_data::TrackData) ->
     let mut changed = false;
 
     ui.label(&track.name);
+    //TODO: use crate::material::param_label for material track names
+
     ui.indent("indent", |ui| {
         changed |= ui
             .checkbox(

--- a/src/editors/matl.rs
+++ b/src/editors/matl.rs
@@ -2,7 +2,7 @@ use crate::{
     app::{MatlEditorState, UiState},
     horizontal_separator_empty,
     material::{
-        add_parameters, apply_preset, default_material, missing_parameters, param_description,
+        add_parameters, apply_preset, default_material, missing_parameters, param_label,
         remove_parameters, unused_parameters, vector4_labels_long, vector4_labels_short,
     },
     presets::{load_json_presets, load_xml_presets},
@@ -1071,13 +1071,4 @@ fn edit_vector_advanced(
     });
 
     changed
-}
-
-fn param_label(p: ParamId) -> String {
-    let description = param_description(p);
-    if !description.is_empty() {
-        format!("{} ({})", p, description)
-    } else {
-        p.to_string()
-    }
 }

--- a/src/material.rs
+++ b/src/material.rs
@@ -555,6 +555,15 @@ pub fn param_description(p: ParamId) -> &'static str {
     }
 }
 
+pub fn param_label(p: ParamId) -> String {
+    let description = param_description(p);
+    if !description.is_empty() {
+        format!("{} ({})", p, description)
+    } else {
+        p.to_string()
+    }
+}
+
 // TODO: Add toggleable tooltips to preferences?
 pub fn vector4_labels_short(p: ParamId) -> [&'static str; 4] {
     // TODO: Research which parameters are unused.


### PR DESCRIPTION
Moved the param_label function since the function can be reused for ANIM editor (which I could not figure out how to implement there so I left a to-do comment)