### PR TITLE
Skel Editor List / Hierarchy Tab

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -155,7 +155,7 @@ pub struct SkelEditorState {
 #[derive(PartialEq, Eq)]
 pub enum SkelMode {
     List,
-    Heirarchy,
+    Hierarchy,
 }
 
 impl Default for SkelMode {


### PR DESCRIPTION
Also fix "hierarchy" spelling mistake. I wish that the tabs didn't have the same font as the grid headings but you can decide on how to go about that. The scroll bar position also is kinda finnicky when switching tabs.
![image](https://user-images.githubusercontent.com/6856627/187018579-101a18fe-9246-4157-aa65-296d2da0911a.png)
![image](https://user-images.githubusercontent.com/6856627/187018562-ff1d8d12-1feb-48d7-af5d-d5d93c3e8f24.png)
