### PR TITLE
Duplicate modl and mesh entries

### DIFF
--- a/src/editors/mesh.rs
+++ b/src/editors/mesh.rs
@@ -124,6 +124,7 @@ fn edit_mesh(
 ) -> bool {
     let mut changed = false;
 
+    let mut mesh_to_duplicate = None;
     let mut mesh_to_remove = None;
 
     // TODO: Avoid allocating here.
@@ -166,6 +167,12 @@ fn edit_mesh(
                 .header_response;
 
             header_response.context_menu(|ui| {
+                if ui.button("Duplicate").clicked() {
+                    ui.close_menu();
+                    mesh_to_duplicate = Some(*item);
+                    changed = true;
+                }
+
                 if ui.button("Delete").clicked() {
                     ui.close_menu();
                     mesh_to_remove = Some(*item);
@@ -188,6 +195,19 @@ fn edit_mesh(
             }
         });
     });
+
+    if let Some(i) = mesh_to_duplicate {
+        let mut duplicated_mesh = mesh.objects[i].clone();
+        duplicated_mesh.subindex = mesh
+            .objects
+            .iter()
+            .filter(|o| o.name == duplicated_mesh.name)
+            .map(|o| o.subindex)
+            .max()
+            .unwrap_or_default()
+            + 1;
+        mesh.objects.insert(i + 1, duplicated_mesh);
+    }
 
     if let Some(i) = mesh_to_remove {
         mesh.objects.remove(i);

--- a/src/editors/modl.rs
+++ b/src/editors/modl.rs
@@ -189,6 +189,7 @@ fn edit_modl_entries(
     ScrollArea::vertical()
         .auto_shrink([false; 2])
         .show(ui, |ui| {
+            let mut entry_to_duplicate = None;
             let mut entry_to_remove = None;
 
             // TODO: Avoid allocating here.
@@ -237,6 +238,12 @@ fn edit_modl_entries(
                                 ui.add(Label::new(mesh_text).sense(egui::Sense::click()));
 
                             name_response.context_menu(|ui| {
+                                if ui.button("Duplicate").clicked() {
+                                    ui.close_menu();
+                                    entry_to_duplicate = Some(*item);
+                                    changed = true;
+                                }
+
                                 if ui.button("Delete").clicked() {
                                     ui.close_menu();
                                     entry_to_remove = Some(*item);
@@ -269,6 +276,11 @@ fn edit_modl_entries(
                     }
                 });
             });
+
+            if let Some(i) = entry_to_duplicate {
+                let duplicated_entry = modl.entries[i].clone();
+                modl.entries.insert(i + 1, duplicated_entry);
+            }
 
             if let Some(i) = entry_to_remove {
                 modl.entries.remove(i);


### PR DESCRIPTION
There is no way to rename modl entries but I still think this is useful.